### PR TITLE
AB#217009: New entity ProjectType

### DIFF
--- a/AI4Green4Students.Test/DataSeeder.cs
+++ b/AI4Green4Students.Test/DataSeeder.cs
@@ -304,7 +304,7 @@ public class DataSeeder
 
     var projectTypeInUse = new Stage
     {
-      Value = Stages.InUse, DisplayName = Stages.InUse, SortOrder = 2, Type = projectTypeStage
+      Value = Stages.Ready, DisplayName = Stages.Ready, SortOrder = 2, Type = projectTypeStage
     };
 
     var projectTypeDeprecated = new Stage

--- a/AI4Green4Students.Test/DataSeeder.cs
+++ b/AI4Green4Students.Test/DataSeeder.cs
@@ -109,13 +109,13 @@ public class DataSeeder
   public async Task SeedProjectType()
   {
     var draftStage = await _db.Stages
-                       .Where(x => x.Type.Value == Defaults.ProjectTypeStage && x.DisplayName == Stages.Draft)
+                       .Where(x => x.Type.Value == ProjectTypeDefaults.StageType && x.DisplayName == Stages.Draft)
                        .FirstOrDefaultAsync()
                      ?? throw new KeyNotFoundException("Stage not found");
 
     var entity = new ProjectType
     {
-      Name = Defaults.ProjectTypeName, Description = "Default project type.", Stage = draftStage
+      Name = ProjectTypeDefaults.Name, Description = "Default project type.", Stage = draftStage
     };
 
     _db.Add(entity);
@@ -124,7 +124,7 @@ public class DataSeeder
 
   public async Task SeedDefaultProject()
   {
-    var type = await _db.ProjectTypes.Where(x=> x.Name == Defaults.ProjectTypeName).SingleAsync();
+    var type = await _db.ProjectTypes.Where(x=> x.Name == ProjectTypeDefaults.Name).SingleAsync();
     var projectOne = new Project { Name = StringConstants.FirstProject, ProjectType = type };
 
     _db.Add(projectOne);
@@ -224,7 +224,7 @@ public class DataSeeder
 
   public async Task SeedDefaultSections()
   {
-    var projectType = await _db.ProjectTypes.SingleAsync(x=> x.Name == Defaults.ProjectTypeName);
+    var projectType = await _db.ProjectTypes.SingleAsync(x=> x.Name == ProjectTypeDefaults.Name);
     var sectionTypes = await _db.SectionTypes.ToListAsync();
 
     var sectionTypePlan = sectionTypes.Single(x => x.Name == SectionTypes.Plan);
@@ -255,7 +255,7 @@ public class DataSeeder
 
   public async Task SeedDefaultFields()
   {
-    var projectType = await _db.ProjectTypes.SingleAsync(x=> x.Name == Defaults.ProjectTypeName);
+    var projectType = await _db.ProjectTypes.SingleAsync(x=> x.Name == ProjectTypeDefaults.Name);
     var sections = await _db.Sections
       .Include(section => section.SectionType)
       .Include(section => section.ProjectType)
@@ -294,7 +294,7 @@ public class DataSeeder
 
   public async Task SeedDefaultStages()
   {
-    var projectTypeStage = new StageType { Value = Defaults.ProjectTypeStage };
+    var projectTypeStage = new StageType { Value = ProjectTypeDefaults.StageType };
     _db.Add(projectTypeStage);
 
     var projectTypeDraft = new Stage

--- a/AI4Green4Students.Test/DataSeeder.cs
+++ b/AI4Green4Students.Test/DataSeeder.cs
@@ -93,21 +93,39 @@ public class DataSeeder
 
   public async Task SeedDefaultTestExperiment()
   {
+    await SeedDefaultSectionAndInputType();
+    await SeedDefaultStages();
+    await SeedDefaultUsers();
+    await SeedProjectType();
     await SeedDefaultProject();
     await SeedDefaultProjectGroup();
-    await SeedDefaultUsers();
     await SeedStudentProjectGroup();
-    await SeedDefaultSectionAndInputType();
     await SeedDefaultSections();
     await SeedDefaultFields();
-    await SeedDefaultStages();
     await SeedDefaultPlans();
     await SeedDefaultFieldResponses();
   }
 
+  public async Task SeedProjectType()
+  {
+    var draftStage = await _db.Stages
+                       .Where(x => x.Type.Value == Defaults.ProjectTypeStage && x.DisplayName == Stages.Draft)
+                       .FirstOrDefaultAsync()
+                     ?? throw new KeyNotFoundException("Stage not found");
+
+    var entity = new ProjectType
+    {
+      Name = Defaults.ProjectTypeName, Description = "Default project type.", Stage = draftStage
+    };
+
+    _db.Add(entity);
+    await _db.SaveChangesAsync();
+  }
+
   public async Task SeedDefaultProject()
   {
-    var projectOne = new Project { Name = StringConstants.FirstProject };
+    var type = await _db.ProjectTypes.Where(x=> x.Name == Defaults.ProjectTypeName).SingleAsync();
+    var projectOne = new Project { Name = StringConstants.FirstProject, ProjectType = type };
 
     _db.Add(projectOne);
     await _db.SaveChangesAsync();
@@ -206,31 +224,29 @@ public class DataSeeder
 
   public async Task SeedDefaultSections()
   {
-    var projects = await _db.Projects.ToListAsync();
+    var projectType = await _db.ProjectTypes.SingleAsync(x=> x.Name == Defaults.ProjectTypeName);
     var sectionTypes = await _db.SectionTypes.ToListAsync();
-
-    var projectOne = projects.Single(x => x.Name == StringConstants.FirstProject);
 
     var sectionTypePlan = sectionTypes.Single(x => x.Name == SectionTypes.Plan);
     var planSections = new List<Section>
     {
-      new Section { Name = StringConstants.PlanFirstSection, SortOrder = 1, Project = projectOne, SectionType = sectionTypePlan },
-      new Section { Name = StringConstants.PlanSecondSection, SortOrder = 2 , Project = projectOne, SectionType = sectionTypePlan },
+      new Section { Name = StringConstants.PlanFirstSection, SortOrder = 1, ProjectType = projectType, SectionType = sectionTypePlan },
+      new Section { Name = StringConstants.PlanSecondSection, SortOrder = 2 , ProjectType = projectType, SectionType = sectionTypePlan },
     };
     foreach (var section in planSections) _db.Add(section);
 
     var sectionTypeReport = sectionTypes.Single(x => x.Name == SectionTypes.Report);
     var reportSections = new List<Section>
     {
-      new Section { Name = StringConstants.ReportFirstSection, SortOrder = 1, Project = projectOne, SectionType = sectionTypeReport },
+      new Section { Name = StringConstants.ReportFirstSection, SortOrder = 1, ProjectType = projectType, SectionType = sectionTypeReport },
     };
     foreach (var section in reportSections) _db.Add(section);
 
     var sectionTypeNote = sectionTypes.Single(x => x.Name == SectionTypes.Note);
     var noteSections = new List<Section>
     {
-      new Section { Name = StringConstants.NoteFirstSection, SortOrder = 1, Project = projectOne, SectionType = sectionTypeNote },
-      new Section { Name = StringConstants.NoteSecondSection, SortOrder = 2, Project = projectOne, SectionType = sectionTypeNote }
+      new Section { Name = StringConstants.NoteFirstSection, SortOrder = 1, ProjectType = projectType, SectionType = sectionTypeNote },
+      new Section { Name = StringConstants.NoteSecondSection, SortOrder = 2, ProjectType = projectType, SectionType = sectionTypeNote }
     };
     foreach (var section in noteSections) _db.Add(section);
 
@@ -239,19 +255,21 @@ public class DataSeeder
 
   public async Task SeedDefaultFields()
   {
-    var projects = await _db.Projects.ToListAsync();
-    var sections = await _db.Sections.Include(section => section.SectionType).ToListAsync();
+    var projectType = await _db.ProjectTypes.SingleAsync(x=> x.Name == Defaults.ProjectTypeName);
+    var sections = await _db.Sections
+      .Include(section => section.SectionType)
+      .Include(section => section.ProjectType)
+      .ToListAsync();
 
     var inputTypes = await _db.InputTypes.ToListAsync();
     var textInput = inputTypes.Single(x => x.Name == InputTypes.Text);
     var numberInput = inputTypes.Single(x => x.Name == InputTypes.Number);
     var description = inputTypes.Single(x => x.Name == InputTypes.Description);
 
-    var projectOne = projects.Single(x => x.Name == StringConstants.FirstProject);
 
-    var planSections = sections.Where(x => x.SectionType.Name == SectionTypes.Plan && x.Project.Id == projectOne.Id).ToList();
-    var reportSections = sections.Where(x => x.SectionType.Name == SectionTypes.Report && x.Project.Id == projectOne.Id).ToList();
-    var noteSections = sections.Where(x => x.SectionType.Name == SectionTypes.Note && x.Project.Id == projectOne.Id).ToList();
+    var planSections = sections.Where(x => x.SectionType.Name == SectionTypes.Plan && x.ProjectType.Id == projectType.Id).ToList();
+    var reportSections = sections.Where(x => x.SectionType.Name == SectionTypes.Report && x.ProjectType.Id == projectType.Id).ToList();
+    var noteSections = sections.Where(x => x.SectionType.Name == SectionTypes.Note && x.ProjectType.Id == projectType.Id).ToList();
 
     // plans sections fields
     var planFirstSection = planSections.Single(x => x.Name == StringConstants.PlanFirstSection);
@@ -276,6 +294,28 @@ public class DataSeeder
 
   public async Task SeedDefaultStages()
   {
+    var projectTypeStage = new StageType { Value = Defaults.ProjectTypeStage };
+    _db.Add(projectTypeStage);
+
+    var projectTypeDraft = new Stage
+    {
+      Value = Stages.Draft, DisplayName = Stages.Draft, SortOrder = 1, Type = projectTypeStage
+    };
+
+    var projectTypeInUse = new Stage
+    {
+      Value = Stages.InUse, DisplayName = Stages.InUse, SortOrder = 2, Type = projectTypeStage
+    };
+
+    var projectTypeDeprecated = new Stage
+    {
+      Value = Stages.Deprecated, DisplayName = Stages.Deprecated, SortOrder = 95, Type = projectTypeStage
+    };
+
+    _db.Add(projectTypeDraft);
+    _db.Add(projectTypeInUse);
+    _db.Add(projectTypeDeprecated);
+
     var planStageType = new StageType { Value = SectionTypes.Plan };
     _db.Add(planStageType);
 

--- a/app/AI4Green4Students/Constants/Defaults.cs
+++ b/app/AI4Green4Students/Constants/Defaults.cs
@@ -1,0 +1,7 @@
+namespace AI4Green4Students.Constants;
+
+public class Defaults
+{
+  public const string ProjectTypeName = "Default";
+  public const string ProjectTypeStage = "ProjectType";
+}

--- a/app/AI4Green4Students/Constants/Defaults.cs
+++ b/app/AI4Green4Students/Constants/Defaults.cs
@@ -1,7 +1,0 @@
-namespace AI4Green4Students.Constants;
-
-public class Defaults
-{
-  public const string ProjectTypeName = "Default";
-  public const string ProjectTypeStage = "ProjectType";
-}

--- a/app/AI4Green4Students/Constants/ProjectTypeDefaults.cs
+++ b/app/AI4Green4Students/Constants/ProjectTypeDefaults.cs
@@ -1,0 +1,7 @@
+namespace AI4Green4Students.Constants;
+
+public class ProjectTypeDefaults
+{
+  public const string Name = "Default";
+  public const string StageType = "ProjectType";
+}

--- a/app/AI4Green4Students/Constants/Stages.cs
+++ b/app/AI4Green4Students/Constants/Stages.cs
@@ -5,12 +5,14 @@ public class Stages
   public const string Draft = "Draft";
   public const string InProgress = "In Progress";
   public const string InReview = "In Review";
+  public const string InUse = "In Use";
   public const string AwaitingChanges = "Awaiting Changes";
   public const string FeedbackRequested = "Feedback Requested";
   public const string InProgressPostFeedback = "In Progress Post-Feedback";
   public const string Approved = "Approved";
   public const string Submitted = "Submitted";
   public const string Locked = "Locked";
+  public const string Deprecated = "Deprecated";
   public const string OnGoing = "On Going";
   public const string Completed = "Completed";
 }

--- a/app/AI4Green4Students/Constants/Stages.cs
+++ b/app/AI4Green4Students/Constants/Stages.cs
@@ -5,7 +5,7 @@ public class Stages
   public const string Draft = "Draft";
   public const string InProgress = "In Progress";
   public const string InReview = "In Review";
-  public const string InUse = "In Use";
+  public const string Ready = "Ready";
   public const string AwaitingChanges = "Awaiting Changes";
   public const string FeedbackRequested = "Feedback Requested";
   public const string InProgressPostFeedback = "In Progress Post-Feedback";

--- a/app/AI4Green4Students/Data/ApplicationDbContext.cs
+++ b/app/AI4Green4Students/Data/ApplicationDbContext.cs
@@ -16,6 +16,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
   public DbSet<FeatureFlag> FeatureFlags => Set<FeatureFlag>();
 
   public DbSet<RegistrationRule> RegistrationRules => Set<RegistrationRule>();
+  public DbSet<ProjectType> ProjectTypes => Set<ProjectType>();
   public DbSet<ProjectGroup> ProjectGroups => Set<ProjectGroup>();
   public DbSet<Project> Projects => Set<Project>();
   public DbSet<Comment> Comments => Set<Comment>();

--- a/app/AI4Green4Students/Data/DataSeeder.cs
+++ b/app/AI4Green4Students/Data/DataSeeder.cs
@@ -167,7 +167,7 @@ public class DataSeeder
 
     var stages = new List<string>
     {
-      Defaults.ProjectTypeStage,
+      ProjectTypeDefaults.StageType,
       SectionTypes.LiteratureReview,
       SectionTypes.Plan,
       SectionTypes.Note,
@@ -196,7 +196,7 @@ public class DataSeeder
 
     var stageConfigs = new Dictionary<string, List<StageConfigModel>>
     {
-      [Defaults.ProjectTypeStage] = new List<StageConfigModel>
+      [ProjectTypeDefaults.StageType] = new List<StageConfigModel>
       {
         new StageConfigModel(1, Stages.Draft),
         new StageConfigModel(2, Stages.Ready),

--- a/app/AI4Green4Students/Data/DataSeeder.cs
+++ b/app/AI4Green4Students/Data/DataSeeder.cs
@@ -167,6 +167,7 @@ public class DataSeeder
 
     var stages = new List<string>
     {
+      Defaults.ProjectTypeStage,
       SectionTypes.LiteratureReview,
       SectionTypes.Plan,
       SectionTypes.Note,
@@ -195,6 +196,12 @@ public class DataSeeder
 
     var stageConfigs = new Dictionary<string, List<StageConfigModel>>
     {
+      [Defaults.ProjectTypeStage] = new List<StageConfigModel>
+      {
+        new StageConfigModel(1, Stages.Draft),
+        new StageConfigModel(2, Stages.InUse),
+        new StageConfigModel(95, Stages.Deprecated),
+      },
       [SectionTypes.LiteratureReview] = new List<StageConfigModel>
       {
         new StageConfigModel(1, Stages.Draft),

--- a/app/AI4Green4Students/Data/DataSeeder.cs
+++ b/app/AI4Green4Students/Data/DataSeeder.cs
@@ -199,7 +199,7 @@ public class DataSeeder
       [Defaults.ProjectTypeStage] = new List<StageConfigModel>
       {
         new StageConfigModel(1, Stages.Draft),
-        new StageConfigModel(2, Stages.InUse),
+        new StageConfigModel(2, Stages.Ready),
         new StageConfigModel(95, Stages.Deprecated),
       },
       [SectionTypes.LiteratureReview] = new List<StageConfigModel>

--- a/app/AI4Green4Students/Data/DefaultExperimentSeeding/DefaultExperimentDataSeeder.cs
+++ b/app/AI4Green4Students/Data/DefaultExperimentSeeding/DefaultExperimentDataSeeder.cs
@@ -1,13 +1,11 @@
 namespace AI4Green4Students.Data.DefaultExperimentSeeding;
 
-using Auth;
 using Constants;
 using Entities;
 using Entities.Identity;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Models.Field;
-using Models.Project;
 using Models.Section;
 using Services;
 
@@ -18,15 +16,13 @@ public class DefaultExperimentDataSeeder
   private readonly InputTypeService _inputTypes;
   private readonly SectionService _sections;
   private readonly SectionTypeService _sectionTypes;
-  private readonly UserManager<ApplicationUser> _users;
 
   public DefaultExperimentDataSeeder(
     ApplicationDbContext db,
     SectionService sections,
     InputTypeService inputTypes,
     FieldService fields,
-    SectionTypeService sectionTypes,
-    UserManager<ApplicationUser> users
+    SectionTypeService sectionTypes
   )
   {
     _db = db;
@@ -34,7 +30,6 @@ public class DefaultExperimentDataSeeder
     _inputTypes = inputTypes;
     _fields = fields;
     _sectionTypes = sectionTypes;
-    _users = users;
   }
 
   /// <summary>
@@ -43,7 +38,7 @@ public class DefaultExperimentDataSeeder
   /// <returns></returns>
   public async Task SeedDefaultExperiment()
   {
-    var project = await SeedProject();
+    var projectTypeId = await SeedProjectType();
 
     var sectionTypes = await _sectionTypes.List();
     // get section types
@@ -54,53 +49,43 @@ public class DefaultExperimentDataSeeder
     var reportSectionType = sectionTypes.Single(x => x.Name == SectionTypes.Report);
 
     //seed sections
-    await SeedProjectGroupSections(project.Id, projectGroupSectionType.Id);
-    await SeedPlanSections(project.Id, planSectionType.Id);
-    await SeedtLiteratureReviewSections(project.Id, literatureReviewSectionType.Id);
-    await SeedNoteSections(project.Id, noteSectionType.Id);
-    await SeedReportSections(project.Id, reportSectionType.Id);
+    await SeedProjectGroupSections(projectTypeId, projectGroupSectionType.Id);
+    await SeedPlanSections(projectTypeId, planSectionType.Id);
+    await SeedLiteratureReviewSections(projectTypeId, literatureReviewSectionType.Id);
+    await SeedNoteSections(projectTypeId, noteSectionType.Id);
+    await SeedReportSections(projectTypeId, reportSectionType.Id);
 
     //seed fields
-    await SeedFields(project.Id);
+    await SeedFields(projectTypeId);
   }
 
   /// <summary>
-  /// Seed project.
+  /// Seed default project type.
   /// </summary>
-  private async Task<ProjectModel> SeedProject()
+  private async Task<int> SeedProjectType()
   {
-    var user = await _users.FindByEmailAsync(SuperUser.EmailAddress);
-    if (user is null)
+    var draftStage = await _db.Stages
+      .Where(x => x.Type.Value == Defaults.ProjectTypeStage && x.DisplayName == Stages.Draft)
+      .FirstOrDefaultAsync()
+      ?? throw new KeyNotFoundException("Stage not found");
+
+    var entity = new ProjectType
     {
-      throw new ApplicationException($"{SuperUser.EmailAddress} not found");
-    }
+      Name = Defaults.ProjectTypeName, Description = "Default project type.", Stage = draftStage
+    };
 
-    var entity = new Project { Name = "AI4Green4Students", Instructors = new List<ApplicationUser> { user } };
-
-    var project = await _db.Projects
-      .Include(x => x.Instructors)
+    var projectType = await _db.ProjectTypes
       .Where(x => EF.Functions.ILike(x.Name, entity.Name))
       .FirstOrDefaultAsync();
 
-    if (project is null)
+    if (projectType is not null)
     {
-      _db.Projects.Add(entity);
-      await _db.SaveChangesAsync();
-      return new ProjectModel { Id = entity.Id, Name = entity.Name };
+      return projectType.Id;
     }
 
-    foreach (var instructor in entity.Instructors)
-    {
-      if (project.Instructors.All(x => x.Id != instructor.Id))
-      {
-        project.Instructors.Add(instructor);
-      }
-    }
-
-    project.Name = entity.Name;
-    _db.Projects.Update(project);
+    _db.ProjectTypes.Add(entity);
     await _db.SaveChangesAsync();
-    return new ProjectModel { Id = project.Id, Name = project.Name };
+    return entity.Id;
   }
 
   /// <summary>
@@ -109,27 +94,21 @@ public class DefaultExperimentDataSeeder
   /// <param name="id">Project id.</param>
   /// <param name="sectionTypeId">Section type (e.g. project group, plan) id.</param>
   private async Task SeedProjectGroupSections(int id, int sectionTypeId)
-    => await _sections.Create(new CreateSectionModel
-    {
-      ProjectId = id,
-      Name = DefaultExperimentConstants.ProjectGroupSummarySection,
-      SortOrder = 1,
-      SectionTypeId = sectionTypeId
-    });
+  {
+    var model = new CreateSectionModel(DefaultExperimentConstants.ProjectGroupSummarySection, id, sectionTypeId, 1);
+    await _sections.Create(model);
+  }
 
   /// <summary>
   /// Seed literature review sections.
   /// </summary>
   /// <param name="id"></param>
   /// <param name="sectionTypeId"></param>
-  private async Task SeedtLiteratureReviewSections(int id, int sectionTypeId)
-    => await _sections.Create(new CreateSectionModel
-    {
-      ProjectId = id,
-      Name = DefaultExperimentConstants.LiteratureReviewSection,
-      SortOrder = 1,
-      SectionTypeId = sectionTypeId
-    });
+  private async Task SeedLiteratureReviewSections(int id, int sectionTypeId)
+  {
+    var model = new CreateSectionModel(DefaultExperimentConstants.LiteratureReviewSection, id, sectionTypeId, 1);
+    await _sections.Create(model);
+  }
 
   /// <summary>
   /// Seed plan sections.
@@ -140,34 +119,10 @@ public class DefaultExperimentDataSeeder
   {
     var sections = new List<CreateSectionModel>
     {
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ReactionSchemeSection,
-        SortOrder = 2,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.CoshhSection,
-        SortOrder = 3,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.SafetyDataSection,
-        SortOrder = 4,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ExperimentalProcecureSection,
-        SortOrder = 5,
-        SectionTypeId = sectionTypeId
-      }
+      new CreateSectionModel(DefaultExperimentConstants.ReactionSchemeSection, id, sectionTypeId, 2),
+      new CreateSectionModel(DefaultExperimentConstants.CoshhSection, id, sectionTypeId, 3),
+      new CreateSectionModel(DefaultExperimentConstants.SafetyDataSection, id, sectionTypeId, 4),
+      new CreateSectionModel(DefaultExperimentConstants.ExperimentalProcecureSection, id, sectionTypeId, 5)
     };
 
     foreach (var section in sections)
@@ -185,62 +140,14 @@ public class DefaultExperimentDataSeeder
   {
     var sections = new List<CreateSectionModel>
     {
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.MetadataSection,
-        SortOrder = 1,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ReactionSchemeSection,
-        SortOrder = 2,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.YieldAndGreenMetricsCalcSection,
-        SortOrder = 3,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ReactionDescriptionSection,
-        SortOrder = 4,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.WorkupDescriptionSection,
-        SortOrder = 5,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.TLCAnalysisSection,
-        SortOrder = 6,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ProductCharacterisatonSection,
-        SortOrder = 7,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ObeservationAndInferencesSection,
-        SortOrder = 8,
-        SectionTypeId = sectionTypeId
-      }
+      new CreateSectionModel(DefaultExperimentConstants.MetadataSection, id, sectionTypeId, 1),
+      new CreateSectionModel(DefaultExperimentConstants.ReactionSchemeSection, id, sectionTypeId, 2),
+      new CreateSectionModel(DefaultExperimentConstants.YieldAndGreenMetricsCalcSection, id, sectionTypeId, 3),
+      new CreateSectionModel(DefaultExperimentConstants.ReactionDescriptionSection, id, sectionTypeId, 4),
+      new CreateSectionModel(DefaultExperimentConstants.WorkupDescriptionSection, id, sectionTypeId, 5),
+      new CreateSectionModel(DefaultExperimentConstants.TLCAnalysisSection, id, sectionTypeId, 6),
+      new CreateSectionModel(DefaultExperimentConstants.ProductCharacterisatonSection, id, sectionTypeId, 7),
+      new CreateSectionModel(DefaultExperimentConstants.ObeservationAndInferencesSection, id, sectionTypeId, 8)
     };
 
     foreach (var section in sections)
@@ -258,55 +165,13 @@ public class DefaultExperimentDataSeeder
   {
     var sections = new List<CreateSectionModel>
     {
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.AbstractSection,
-        SortOrder = 1,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.IntroductionSection,
-        SortOrder = 2,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ResultsAndDiscussionSection,
-        SortOrder = 3,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ConclusionSection,
-        SortOrder = 4,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ExperimentalSection,
-        SortOrder = 5,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.ReferencesSection,
-        SortOrder = 6,
-        SectionTypeId = sectionTypeId
-      },
-      new CreateSectionModel
-      {
-        ProjectId = id,
-        Name = DefaultExperimentConstants.SupportingInfoSection,
-        SortOrder = 7,
-        SectionTypeId = sectionTypeId
-      }
+      new CreateSectionModel(DefaultExperimentConstants.AbstractSection, id, sectionTypeId, 1),
+      new CreateSectionModel(DefaultExperimentConstants.IntroductionSection, id, sectionTypeId, 2),
+      new CreateSectionModel(DefaultExperimentConstants.ResultsAndDiscussionSection, id, sectionTypeId, 3),
+      new CreateSectionModel(DefaultExperimentConstants.ConclusionSection, id, sectionTypeId, 4),
+      new CreateSectionModel(DefaultExperimentConstants.ExperimentalSection, id, sectionTypeId, 5),
+      new CreateSectionModel(DefaultExperimentConstants.ReferencesSection, id, sectionTypeId, 6),
+      new CreateSectionModel(DefaultExperimentConstants.SupportingInfoSection, id, sectionTypeId, 7)
     };
 
     foreach (var section in sections)
@@ -958,6 +823,6 @@ public class DefaultExperimentDataSeeder
   private async Task<SectionModel> GetSection(int id, string name, string sectionType)
   {
     var sections = await _sections.List();
-    return sections.First(x => x.ProjectId == id && x.Name == name && x.SectionType.Name == sectionType);
+    return sections.First(x => x.ProjectType.Id == id && x.Name == name && x.SectionType.Name == sectionType);
   }
 }

--- a/app/AI4Green4Students/Data/DefaultExperimentSeeding/DefaultExperimentDataSeeder.cs
+++ b/app/AI4Green4Students/Data/DefaultExperimentSeeding/DefaultExperimentDataSeeder.cs
@@ -64,14 +64,14 @@ public class DefaultExperimentDataSeeder
   /// </summary>
   private async Task<int> SeedProjectType()
   {
-    var draftStage = await _db.Stages
-      .Where(x => x.Type.Value == Defaults.ProjectTypeStage && x.DisplayName == Stages.Draft)
+    var readyStage = await _db.Stages
+      .Where(x => x.Type.Value == Defaults.ProjectTypeStage && x.DisplayName == Stages.Ready)
       .FirstOrDefaultAsync()
       ?? throw new KeyNotFoundException("Stage not found");
 
     var entity = new ProjectType
     {
-      Name = Defaults.ProjectTypeName, Description = "Default project type.", Stage = draftStage
+      Name = Defaults.ProjectTypeName, Description = "Default project type.", Stage = readyStage
     };
 
     var projectType = await _db.ProjectTypes

--- a/app/AI4Green4Students/Data/DefaultExperimentSeeding/DefaultExperimentDataSeeder.cs
+++ b/app/AI4Green4Students/Data/DefaultExperimentSeeding/DefaultExperimentDataSeeder.cs
@@ -65,13 +65,13 @@ public class DefaultExperimentDataSeeder
   private async Task<int> SeedProjectType()
   {
     var readyStage = await _db.Stages
-      .Where(x => x.Type.Value == Defaults.ProjectTypeStage && x.DisplayName == Stages.Ready)
+      .Where(x => x.Type.Value == ProjectTypeDefaults.StageType && x.DisplayName == Stages.Ready)
       .FirstOrDefaultAsync()
       ?? throw new KeyNotFoundException("Stage not found");
 
     var entity = new ProjectType
     {
-      Name = Defaults.ProjectTypeName, Description = "Default project type.", Stage = readyStage
+      Name = ProjectTypeDefaults.Name, Description = "Default project type.", Stage = readyStage
     };
 
     var projectType = await _db.ProjectTypes

--- a/app/AI4Green4Students/Data/Entities/Field.cs
+++ b/app/AI4Green4Students/Data/Entities/Field.cs
@@ -6,15 +6,15 @@ namespace AI4Green4Students.Data.Entities;
 public class Field
 {
   public int Id { get; set; }
-  public string Name { get; set; } = string.Empty;
+  public required string Name { get; set; }
   public int SortOrder { get; set; }
-  public InputType InputType { get; set; } = null!;
+  public required InputType InputType { get; set; }
   public string? TriggerCause { get; set; }
   public Field? TriggerTarget { get; set; }
   public bool Mandatory { get; set; } = true;
-  public Section Section { get; set; } = new();
+  public required Section Section { get; set; }
   public bool Hidden { get; set; }
-  public List<FieldResponse> FieldResponses { get; set; } = new();
-  public List<SelectFieldOption> SelectFieldOptions { get; set; } = new();
+  public List<FieldResponse> FieldResponses { get; set; } = new List<FieldResponse>();
+  public List<SelectFieldOption> SelectFieldOptions { get; set; } = new List<SelectFieldOption>();
   public string DefaultResponse { get; set; } = string.Empty;
 }

--- a/app/AI4Green4Students/Data/Entities/Project.cs
+++ b/app/AI4Green4Students/Data/Entities/Project.cs
@@ -6,11 +6,11 @@ namespace AI4Green4Students.Data.Entities;
 public class Project
 {
   public int Id { get; set; }
-  public string Name { get; set; } = string.Empty;
-  public List<ProjectGroup> ProjectGroups { get; set; } = null!;
-  public List<Plan> Plans { get; set; } = null!;
-  public List<Note> Notes { get; set; } = null!;
-  public List<Report> Reports { get; set; } = null!;
-  public List<Section> Sections { get; set; } = null!;
-  public List<ApplicationUser> Instructors { get; set; } = new();
+  public required string Name { get; set; }
+  public List<ProjectGroup> ProjectGroups { get; set; } = new  List<ProjectGroup>();
+  public List<Plan> Plans { get; set; } = new List<Plan>();
+  public List<Note> Notes { get; set; } = new List<Note>();
+  public List<Report> Reports { get; set; } = new List<Report>();
+  public List<ApplicationUser> Instructors { get; set; } = new List<ApplicationUser>();
+  public ProjectType? ProjectType { get; set; }
 }

--- a/app/AI4Green4Students/Data/Entities/ProjectType.cs
+++ b/app/AI4Green4Students/Data/Entities/ProjectType.cs
@@ -1,0 +1,10 @@
+namespace AI4Green4Students.Data.Entities;
+
+public class ProjectType
+{
+  public int Id { get; set; }
+  public required string Name { get; set; }
+  public string Description { get; set; } = string.Empty;
+  public required Stage Stage { get; set; }
+  public List<Section> Sections { get; set; } = new List<Section>();
+}

--- a/app/AI4Green4Students/Data/Entities/Section.cs
+++ b/app/AI4Green4Students/Data/Entities/Section.cs
@@ -1,16 +1,14 @@
-using Microsoft.Identity.Client;
-
 namespace AI4Green4Students.Data.Entities;
 
 /// <summary>
-/// A section splits up the fields for an experiment. Each section can be approved by the instructor.
+/// Represents a section within a section type (e.g. Plan or Lab-Note).
 /// </summary>
 public class Section
 {
   public int Id { get; set; }
-  public string Name { get; set; } = string.Empty;
-  public Project Project { get; set; } = null!;
-  public List<Field> Fields { get; set; } = null!;
+  public required string Name { get; set; }
+  public ProjectType? ProjectType { get; set; }
+  public int SortOrder { get; set; }
+  public List<Field> Fields { get; set; } = new List<Field>();
   public SectionType SectionType { get; set; } = null!;
-  public int SortOrder { get; set; } = 0;
 }

--- a/app/AI4Green4Students/Data/Entities/SectionType.cs
+++ b/app/AI4Green4Students/Data/Entities/SectionType.cs
@@ -3,6 +3,6 @@ namespace AI4Green4Students.Data.Entities;
 public class SectionType
 {
   public int Id { get; set; }
-  public string Name { get; set; } = string.Empty;
-  public List<Section> Sections { get; set; } = null!;
+  public required string Name { get; set; }
+  public List<Section> Sections { get; set; } = new List<Section>();
 }

--- a/app/AI4Green4Students/Data/Entities/SelectFieldOption.cs
+++ b/app/AI4Green4Students/Data/Entities/SelectFieldOption.cs
@@ -6,6 +6,6 @@ namespace AI4Green4Students.Data.Entities;
 public class SelectFieldOption
 {
   public int Id { get; set; }
-  public string Name { get; set; } = string.Empty;
-  public Field Field { get; set; } = new Field();
+  public required string Name { get; set; }
+  public Field Field { get; set; } = null!;
 }

--- a/app/AI4Green4Students/Migrations/20250820130420_AddProjectType.Designer.cs
+++ b/app/AI4Green4Students/Migrations/20250820130420_AddProjectType.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AI4Green4Students.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AI4Green4Students.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250820130420_AddProjectType")]
+    partial class AddProjectType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/app/AI4Green4Students/Migrations/20250820130420_AddProjectType.cs
+++ b/app/AI4Green4Students/Migrations/20250820130420_AddProjectType.cs
@@ -1,0 +1,140 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace AI4Green4Students.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProjectType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Sections_Projects_ProjectId",
+                table: "Sections");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Sections_ProjectId",
+                table: "Sections");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectId",
+                table: "Sections");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ProjectTypeId",
+                table: "Sections",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ProjectTypeId",
+                table: "Projects",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ProjectTypes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: false),
+                    StageId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProjectTypes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProjectTypes_Stages_StageId",
+                        column: x => x.StageId,
+                        principalTable: "Stages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sections_ProjectTypeId",
+                table: "Sections",
+                column: "ProjectTypeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_ProjectTypeId",
+                table: "Projects",
+                column: "ProjectTypeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProjectTypes_StageId",
+                table: "ProjectTypes",
+                column: "StageId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Projects_ProjectTypes_ProjectTypeId",
+                table: "Projects",
+                column: "ProjectTypeId",
+                principalTable: "ProjectTypes",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Sections_ProjectTypes_ProjectTypeId",
+                table: "Sections",
+                column: "ProjectTypeId",
+                principalTable: "ProjectTypes",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Projects_ProjectTypes_ProjectTypeId",
+                table: "Projects");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Sections_ProjectTypes_ProjectTypeId",
+                table: "Sections");
+
+            migrationBuilder.DropTable(
+                name: "ProjectTypes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Sections_ProjectTypeId",
+                table: "Sections");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_ProjectTypeId",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectTypeId",
+                table: "Sections");
+
+            migrationBuilder.DropColumn(
+                name: "ProjectTypeId",
+                table: "Projects");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ProjectId",
+                table: "Sections",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sections_ProjectId",
+                table: "Sections",
+                column: "ProjectId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Sections_Projects_ProjectId",
+                table: "Sections",
+                column: "ProjectId",
+                principalTable: "Projects",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/app/AI4Green4Students/Models/Project/CreateProjectModel.cs
+++ b/app/AI4Green4Students/Models/Project/CreateProjectModel.cs
@@ -1,9 +1,3 @@
-using AI4Green4Students.Data.Entities.Identity;
-
 namespace AI4Green4Students.Models.Project;
 
-public record CreateProjectModel
-{
-  public string Name { get; init; } = string.Empty;
-  public List<string> InstructorIds { get; init; } = new List<string>();
-}
+public record CreateProjectModel(string Name, List<string> InstructorIds, int ProjectTypeId);

--- a/app/AI4Green4Students/Models/Project/ProjectModel.cs
+++ b/app/AI4Green4Students/Models/Project/ProjectModel.cs
@@ -1,23 +1,23 @@
 namespace AI4Green4Students.Models.Project;
 
-public class ProjectModel
+public record ProjectModel(
+  int Id,
+  string Name,
+  string Stage,
+  List<ProjectGroupModel> ProjectGroups,
+  ProjectTypeModel ProjectType
+)
 {
-  public ProjectModel(Data.Entities.Project entity)
-  {
-    Id = entity.Id;
-    Name = entity.Name;
-    ProjectGroups = entity.ProjectGroups?.Select(x => new ProjectGroupModel(x.Id, x.Name)).ToList() ??
-                    new List<ProjectGroupModel>();
-  }
-
-  public ProjectModel()
+  public ProjectModel(Data.Entities.Project entity) : this(
+    entity.Id,
+    entity.Name,
+    string.Empty,
+    entity.ProjectGroups.Select(x => new ProjectGroupModel(x.Id, x.Name)).ToList(),
+    new ProjectTypeModel(entity.ProjectType.Id, entity.ProjectType.Name, entity.ProjectType.Description)
+  )
   {
   }
-
-  public int Id { get; set; }
-  public string Name { get; set; } = string.Empty;
-  public string Stage { get; set; } = string.Empty; // More of a status than a stage for now.
-  public List<ProjectGroupModel> ProjectGroups { get; set; } = new();
-};
+}
 
 public record ProjectGroupModel(int Id, string Name);
+public record ProjectTypeModel(int Id, string Name, string Description);

--- a/app/AI4Green4Students/Models/Section/CreateSectionModel.cs
+++ b/app/AI4Green4Students/Models/Section/CreateSectionModel.cs
@@ -1,9 +1,3 @@
 namespace AI4Green4Students.Models.Section;
 
-public class CreateSectionModel
-{
-  public string Name { get; set; } = string.Empty;
-  public int ProjectId { get; set; }
-  public int SectionTypeId { get; set; }
-  public int SortOrder { get; set; }
-}
+public record CreateSectionModel(string Name, int ProjectTypeId, int SectionTypeId, int SortOrder);

--- a/app/AI4Green4Students/Models/Section/SectionModel.cs
+++ b/app/AI4Green4Students/Models/Section/SectionModel.cs
@@ -2,23 +2,28 @@ using AI4Green4Students.Models.SectionType;
 
 namespace AI4Green4Students.Models.Section;
 
-public class SectionModel
+public record SectionModel(
+  int Id,
+  string Name,
+  int SortOrder,
+  SectionTypeModel SectionType,
+  SectionProjectTypeModel? ProjectType
+)
 {
-  public SectionModel()
-  { }
-
   public SectionModel(Data.Entities.Section entity)
+    : this(
+      entity.Id,
+      entity.Name,
+      entity.SortOrder,
+      new SectionTypeModel(entity.SectionType),
+      entity.ProjectType == null
+        ? null
+        : new SectionProjectTypeModel(entity.ProjectType.Id, entity.ProjectType.Name, entity.ProjectType.Description)
+    )
   {
-    Id = entity.Id;
-    Name = entity.Name;
-    SortOrder = entity.SortOrder;
-    SectionType = new SectionTypeModel(entity.SectionType);
-    ProjectId = entity.Project.Id;
   }
-
-  public int Id { get; set; }
-  public string Name { get; set; } = string.Empty;
-  public int SortOrder { get; set; }
-  public int ProjectId { get; set; }
-  public SectionTypeModel SectionType { get; set; } = null!;
 }
+
+public record ProjectSectionModel(int Id, SectionModel Section);
+
+public record SectionProjectTypeModel(int Id, string Name, string Description);

--- a/app/AI4Green4Students/Services/FieldService.cs
+++ b/app/AI4Green4Students/Services/FieldService.cs
@@ -118,6 +118,7 @@ public class FieldService
     var result = await _db.Fields
                    .AsNoTracking()
                    .Where(x => x.Id == id)
+                   .Include(x => x.Section)
                    .Include(x => x.InputType)
                    .Include(x => x.TriggerTarget)
                    .Include(x => x.SelectFieldOptions)
@@ -138,6 +139,7 @@ public class FieldService
                    .AsNoTracking()
                    .Where(x => x.Id == id)
                    .Include(x => x.Field)
+                   .Include(x => x.Field.Section)
                    .Include(x => x.Field.InputType)
                    .Include(x => x.Field.SelectFieldOptions)
                    .Select(x=> x.Field)
@@ -171,14 +173,21 @@ public class FieldService
   /// </param>
   /// <returns>Section type fields list</returns>
   public async Task<List<Field>> ListBySectionType(string sectionType, int projectId)
-    => await _db.Fields
+  {
+    var project = await _db.Projects
+      .Include(x => x.ProjectType)
+      .FirstOrDefaultAsync(x => x.Id == projectId)
+      ?? throw new KeyNotFoundException("Project not found");
+
+    return await _db.Fields
       .Include(x => x.Section)
       .Include(x => x.InputType)
       .Include(x => x.SelectFieldOptions)
       .Include(x => x.TriggerTarget)
-      .Where(x => x.Section.SectionType.Name == sectionType && x.Section.Project.Id == projectId)
+      .Where(x => x.Section.SectionType.Name == sectionType && x.Section.ProjectType.Id == project.ProjectType.Id)
       .ToListAsync();
-  
+  }
+
   /// <summary>
   /// Get a list of fields for a given section.
   /// </summary>

--- a/app/AI4Green4Students/Services/NoteService.cs
+++ b/app/AI4Green4Students/Services/NoteService.cs
@@ -294,13 +294,20 @@ public class NoteService : BaseSectionTypeService<Note>
   /// <param name="fieldName">Field name to get the id for.</param>
   /// <returns>Field id.</returns>
   private async Task<int?> GetFieldId(int projectId, string sectionName, string fieldName)
-    => (await _db.Fields.AsNoTracking()
+  {
+    var project = await _db.Projects.AsNoTracking()
+                    .Include(x => x.ProjectType)
+                    .FirstOrDefaultAsync(x => x.Id == projectId)
+                  ?? throw new KeyNotFoundException("Project not found");
+
+    return (await _db.Fields.AsNoTracking()
       .SingleOrDefaultAsync(x =>
-        x.Section.Project.Id == projectId &&
+        x.Section.ProjectType.Id == project.ProjectType.Id &&
         x.Section.SectionType.Name == SectionTypes.Note &&
         x.Section.Name == sectionName &&
-        x.Name.ToLower() == fieldName.ToLower()
+        EF.Functions.ILike(x.Section.Name, sectionName)
       ))?.Id;
+  }
 
   /// <summary>
   /// Get a note feedback model.

--- a/app/AI4Green4Students/Services/PlanService.cs
+++ b/app/AI4Green4Students/Services/PlanService.cs
@@ -212,14 +212,21 @@ public class PlanService : BaseSectionTypeService<Plan>
   /// <param name="value">Reaction scheme value.</param>
   private async Task CreateNoteReactionScheme(int projectId, int noteId, string value)
   {
-    var reactionSchemeField = await _db.Fields
-      .Where(x => x.InputType.Name == InputTypes.ReactionScheme && x.Section.Project.Id == projectId)
-      .FirstOrDefaultAsync() ?? throw new KeyNotFoundException("Reaction scheme field not found.");
+    var project = await _db.Projects.AsNoTracking()
+                    .Include(x => x.ProjectType)
+                    .FirstOrDefaultAsync(x => x.Id == projectId)
+                  ?? throw new KeyNotFoundException("Project not found.");
+
+    var field = await _db.Fields.Where(x =>
+                    x.InputType.Name == InputTypes.ReactionScheme &&
+                    x.Section.ProjectType.Id == project.ProjectType.Id)
+                  .FirstOrDefaultAsync()
+                ?? throw new KeyNotFoundException("Reaction scheme field not found.");
 
     var note = await _db.Notes.Where(x => x.Id == noteId).FirstOrDefaultAsync() ??
                throw new KeyNotFoundException("Note not found.");
 
-    var fieldResponse = await _fieldResponses.Create(reactionSchemeField, value);
+    var fieldResponse = await _fieldResponses.Create(field, value);
     note.FieldResponses = [fieldResponse];
 
     _db.Update(note);

--- a/app/AI4Green4Students/Services/ProjectGroupService.cs
+++ b/app/AI4Green4Students/Services/ProjectGroupService.cs
@@ -357,9 +357,16 @@ public class ProjectGroupService
   /// <returns>Section form.</returns>
   public async Task<SectionFormModel> GetSectionForm(int id)
   {
-    var pg = await Get(id);
+    var pg = await _db.ProjectGroups.AsNoTracking()
+      .Where(x => x.Id == id)
+      .Include(x => x.Project)
+      .ThenInclude(x => x.ProjectType)
+      .FirstOrDefaultAsync() ?? throw new KeyNotFoundException("Project Group not found.");
+
     var pgSection = await _db.Sections.AsNoTracking()
-                      .Where(x => x.SectionType.Name == SectionTypes.ProjectGroup && x.Project.Id == pg.ProjectId)
+                      .Where(x =>
+                        x.SectionType.Name == SectionTypes.ProjectGroup &&
+                        x.ProjectType.Id == pg.Project.ProjectType.Id)
                       .FirstAsync()
                     ?? throw new KeyNotFoundException();
     return await _sectionForm.GetSectionForm<ProjectGroup>(id, pgSection.Id);
@@ -419,10 +426,15 @@ public class ProjectGroupService
   }
 
   private IQueryable<ProjectGroup> QueryWithStudents()
-    => _db.ProjectGroups.AsQueryable().Include(x => x.Project).Include(x => x.Students);
+    => _db.ProjectGroups.AsQueryable()
+      .Include(x => x.Project)
+      .ThenInclude(x => x.ProjectType)
+      .Include(x => x.Students);
 
   private IQueryable<ProjectGroup> Query()
-    => _db.ProjectGroups.AsQueryable().Include(x => x.Project);
+    => _db.ProjectGroups.AsQueryable()
+      .Include(x => x.Project)
+      .ThenInclude(x => x.ProjectType);
 
   /// <summary>
   /// Parse date string to DateTimeOffset.

--- a/app/AI4Green4Students/Services/ProjectService.cs
+++ b/app/AI4Green4Students/Services/ProjectService.cs
@@ -36,6 +36,7 @@ public class ProjectService
   {
     var projects = await _db.Projects.AsNoTracking()
       .Include(x => x.ProjectGroups)
+      .Include(x => x.ProjectType)
       .Where(x => x.Instructors.Any(y => y.Id == userId))
       .ToListAsync();
 
@@ -59,6 +60,7 @@ public class ProjectService
   {
     var userProjects = await _db.Projects.AsNoTracking()
       .Include(x => x.ProjectGroups).ThenInclude(y => y.Students)
+      .Include(x => x.ProjectType)
       .Where(x => x.ProjectGroups.Any(y => y.Students.Any(z => z.Id == userId)))
       .AsSplitQuery()
       .ToListAsync();
@@ -87,6 +89,7 @@ public class ProjectService
   {
     var project = await _db.Projects.AsNoTracking()
                     .Include(x => x.ProjectGroups)
+                    .Include(x => x.ProjectType)
                     .Where(x => x.Id == id).SingleOrDefaultAsync()
                   ?? throw new KeyNotFoundException();
 
@@ -106,6 +109,7 @@ public class ProjectService
   {
     var project = await _db.Projects.AsNoTracking()
                     .Include(x => x.ProjectGroups)
+                    .Include(x => x.ProjectType)
                     .Where(x => x.Id == id && x.Instructors.Any(y => y.Id == userId))
                     .SingleOrDefaultAsync()
                   ?? throw new KeyNotFoundException();
@@ -126,6 +130,7 @@ public class ProjectService
   {
     var result = await _db.Projects.AsNoTracking()
                    .Where(x => x.Id == id && x.ProjectGroups.Any(y => y.Students.Any(z => z.Id == userId)))
+                   .Include(x => x.ProjectType)
                    .Select(x => new
                    {
                      Project = x,
@@ -171,10 +176,15 @@ public class ProjectService
       return await Set(isExistingValue.Id, model);
     }
 
+    var projectType = await _db.ProjectTypes.Where(x => x.Id == model.ProjectTypeId).FirstOrDefaultAsync()
+                      ?? throw new KeyNotFoundException("Project type not found");
+
     var instructors = _db.Users.Where(x => model.InstructorIds.Contains(x.Id)).ToList();
     var entity = new Project
     {
-      Name = model.Name, Instructors = instructors
+      ProjectType = projectType,
+      Name = model.Name,
+      Instructors = instructors
     };
 
     await _db.Projects.AddAsync(entity);

--- a/app/AI4Green4Students/Services/SectionService.cs
+++ b/app/AI4Green4Students/Services/SectionService.cs
@@ -21,22 +21,25 @@ public class SectionService
   public async Task<List<SectionModel>> List()
     => await _db.Sections.AsNoTracking()
       .Include(x => x.SectionType)
-      .Include(x => x.Project)
-      .Select(x => new SectionModel(x)).ToListAsync();
-  
+      .Include(x => x.ProjectType)
+      .Select(x => new SectionModel(x))
+      .ToListAsync();
   /// <summary>
   /// Get all sections of a project.
   /// </summary>
-  /// <param name="projectId">Project id</param>
+  /// <param name="id">Project id</param>
   /// <returns>Sections list of a specific type</returns>
-  public async Task<List<SectionModel>> ListByProject(int projectId)
-    => await _db.Sections.AsNoTracking()
-      .Where(x => x.Project.Id == projectId)
+  public async Task<List<SectionModel>> ListByProject(int id)
+  {
+    var project = await GetProject(id);
+    return await _db.Sections.AsNoTracking()
+      .Where(x => x.ProjectType.Id == project.ProjectType.Id)
       .Include(x => x.SectionType)
-      .Include(x => x.Project)
+      .Include(x => x.ProjectType)
       .Select(x => new SectionModel(x))
       .ToListAsync();
-  
+  }
+
   /// <summary>
   /// Get all sections of a specific type.
   /// </summary>
@@ -44,12 +47,17 @@ public class SectionService
   /// <param name="projectId">Project id</param>
   /// <returns>Sections list of a specific type</returns>
   public async Task<List<SectionModel>> ListBySectionTypeName(string sectionType, int projectId)
-    => await _db.Sections.AsNoTracking()
-      .Where(x => x.SectionType.Name == sectionType && x.Project.Id == projectId)
+  {
+    var project = await GetProject(projectId);
+    return await _db.Sections.AsNoTracking()
+      .Where(x =>
+        EF.Functions.ILike(x.SectionType.Name, sectionType) &&
+        x.ProjectType.Id == project.ProjectType.Id)
       .Include(x => x.SectionType)
-      .Include(x => x.Project)
+      .Include(x => x.ProjectType)
       .Select(x => new SectionModel(x))
       .ToListAsync();
+  }
 
   /// <summary>
   /// Create a new section. Section are associated to a project.
@@ -59,21 +67,22 @@ public class SectionService
   /// <returns>Newly created section</returns>
   public async Task<SectionModel> Create(CreateSectionModel model)
   {
-    var isExistingValue = await _db.Sections
-      .Where(x => EF.Functions.ILike(x.Name, model.Name) &&
-                  x.SectionType.Id == model.SectionTypeId &&
-                  x.Project.Id == model.ProjectId)
-      .Include(x => x.Project)
+    var existing = await _db.Sections.AsNoTracking()
+      .Where(x =>
+        EF.Functions.ILike(x.Name, model.Name) &&
+        x.SectionType.Id == model.SectionTypeId &&
+        x.ProjectType.Id == model.ProjectTypeId
+      )
       .FirstOrDefaultAsync();
 
-    if (isExistingValue is not null)
-      return await Set(isExistingValue.Id, model); // Update existing Section if it exists
+    if (existing is not null)
+      return await Set(existing.Id, model); // Update existing Section if it exists
 
     // Else, create new Section
     var entity = new Section()
     {
       Name = model.Name,
-      Project = await _db.Projects.SingleOrDefaultAsync(x => x.Id == model.ProjectId)
+      ProjectType = await _db.ProjectTypes.SingleOrDefaultAsync(x => x.Id == model.ProjectTypeId)
                 ?? throw new KeyNotFoundException(),
       SectionType = await _db.SectionTypes.SingleOrDefaultAsync(x => x.Id == model.SectionTypeId)
                     ?? throw new KeyNotFoundException(),
@@ -99,8 +108,6 @@ public class SectionService
                    .FirstOrDefaultAsync()
                  ?? throw new KeyNotFoundException(); // if section does not exist
 
-    entity.Project = await _db.Projects.SingleOrDefaultAsync(x => x.Id == model.ProjectId)
-                     ?? throw new KeyNotFoundException();
     entity.SectionType = await _db.SectionTypes.SingleOrDefaultAsync(x => x.Id == model.SectionTypeId)
                          ?? throw new KeyNotFoundException();
     entity.Name = model.Name;
@@ -121,8 +128,16 @@ public class SectionService
          .AsNoTracking()
          .Where(x => x.Id == id)
          .Include(x => x.SectionType)
-         .Include(x => x.Project)
+         .Include(x => x.ProjectType)
          .Select(x => new SectionModel(x))
          .SingleOrDefaultAsync()
        ?? throw new KeyNotFoundException();
+
+  private async Task<Project> GetProject(int id)
+    => await _db.Projects
+         .AsNoTracking()
+         .Where(x => x.Id == id)
+         .Include(x => x.ProjectType)
+         .FirstOrDefaultAsync()
+       ?? throw new KeyNotFoundException("Project not found");
 }

--- a/app/AI4Green4Students/Services/SectionTypeService.cs
+++ b/app/AI4Green4Students/Services/SectionTypeService.cs
@@ -22,14 +22,6 @@ public class SectionTypeService
       .Select(x => new SectionTypeModel(x))
       .ToListAsync();
   
-  public async Task<List<SectionTypeModel>> ListByProject(int projectId)
-    => 
-      await _db.SectionTypes
-        .AsNoTracking()
-        .Where(x => x.Sections.Any(y => y.Project.Id == projectId))
-        .Select(x => new SectionTypeModel(x))
-        .ToListAsync();
-  
   public async Task<SectionTypeModel> Get(int id)
   {
     var result = await _db.SectionTypes

--- a/app/AI4Green4Students/Startup/Web/WebInitialisation.cs
+++ b/app/AI4Green4Students/Startup/Web/WebInitialisation.cs
@@ -60,7 +60,7 @@ public static class WebInitialisation
 
         //todo - move this to a CLI command for creating default experiment, complete with fields
         //We may keep this seeding option in as an example experiment for users to look at
-        var defaultExperimentSeeder = new DefaultExperimentDataSeeder(db, sections, inputTypes, fields, sectionTypes, users);
+        var defaultExperimentSeeder = new DefaultExperimentDataSeeder(db, sections, inputTypes, fields, sectionTypes);
         await defaultExperimentSeeder.SeedDefaultExperiment();
         
     }


### PR DESCRIPTION
## Overview

The PR mainly adds new entity `ProjectType` and updates `Project` and `Section` entities to reference it. The PR updates relevant services and changes the existing default Project seeding to Project type seeding as a result of the entity change. The PR also adds new stage type and stages for `Project Type`.

## Azure Boards

- AB#217306
- AB#218843
- AB#218844
- AB#218840
- AB#218841
- AB#218842
- AB#218843
- AB#217014
- AB#218845